### PR TITLE
Add Domain Layer

### DIFF
--- a/app/src/main/java/com/sandoval/thalesemployee/data/network/Failure.kt
+++ b/app/src/main/java/com/sandoval/thalesemployee/data/network/Failure.kt
@@ -1,0 +1,13 @@
+package com.sandoval.thalesemployee.data.network
+
+sealed class Failure {
+
+    object NetworkConnection : Failure()
+    object DataError : Failure()
+    object ServerError : Failure()
+
+    //This class can be extended to be able to get specific errors
+    data class FeatureFailure(
+        val errorBody: String
+    ) : Failure()
+}

--- a/app/src/main/java/com/sandoval/thalesemployee/data/remote/repository/RemoteDataGetEmployeeListRepository.kt
+++ b/app/src/main/java/com/sandoval/thalesemployee/data/remote/repository/RemoteDataGetEmployeeListRepository.kt
@@ -1,4 +1,19 @@
 package com.sandoval.thalesemployee.data.remote.repository
 
-class RemoteDataGetEmployeeListRepository {
+import com.sandoval.thalesemployee.data.network.Failure
+import com.sandoval.thalesemployee.data.remote.api.ThalesEmployeeService
+import com.sandoval.thalesemployee.data.utils.Either
+import com.sandoval.thalesemployee.domain.models.employee_list.DData
+import com.sandoval.thalesemployee.domain.repository.IGetEmployeeListRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+class RemoteDataGetEmployeeListRepository @Inject constructor(
+    private val thalesEmployeeService: ThalesEmployeeService
+) : IGetEmployeeListRepository {
+    override suspend fun getEmployeeList(): Flow<Either<Failure, List<DData>>> = flow {
+        val res = thalesEmployeeService.getEmployeesList()
+        //TODO Emit the result mapping the data through the domain
+    }
 }

--- a/app/src/main/java/com/sandoval/thalesemployee/data/utils/Either.kt
+++ b/app/src/main/java/com/sandoval/thalesemployee/data/utils/Either.kt
@@ -1,0 +1,63 @@
+package com.sandoval.thalesemployee.data.utils
+
+/**
+ * Represents a value of one of two possible types (a disjoint union).
+ * Instances of [Either] are either an instance of [Left] or [Right].
+ * FP Convention dictates that [Left] is used for "failure"
+ * and [Right] is used for "success".
+ *
+ * @see Left
+ * @see Right
+ */
+sealed class Either<out L, out R> {
+    /** * Represents the left side of [Either] class which by convention is a "Failure". */
+    data class Left<out L>(val a: L) : Either<L, Nothing>()
+
+    /** * Represents the right side of [Either] class which by convention is a "Success". */
+    data class Right<out R>(val b: R) : Either<Nothing, R>()
+
+    /**
+     * Returns true if this is a Right, false otherwise.
+     * @see Right
+     */
+    val isRight get() = this is Right<R>
+
+    /**
+     * Returns true if this is a Left, false otherwise.
+     * @see Left
+     */
+    val isLeft get() = this is Left<L>
+
+    /**
+     * Creates a Left type.
+     * @see Left
+     */
+    fun <L> left(a: L) =
+        Left(a)
+
+    /**
+     * Creates a Left type.
+     * @see Right
+     */
+    fun <R> right(b: R) =
+        Right(b)
+
+    /**
+     * Applies fnL if this is a Left or fnR if this is a Right.
+     * @see Left
+     * @see Right
+     */
+    fun fold(fnL: (L) -> Any, fnR: (R) -> Any): Any =
+        when (this) {
+            is Left -> fnL(a)
+            is Right -> fnR(b)
+        }
+}
+
+/**
+ * Composes 2 functions
+ * See <a href="https://proandroiddev.com/kotlins-nothing-type-946de7d464fb">Credits to Alex Hart.</a>
+ */
+fun <A, B, C> ((A) -> B).c(f: (B) -> C): (A) -> C = {
+    f(this(it))
+}

--- a/app/src/main/java/com/sandoval/thalesemployee/domain/base/BaseUseCase.kt
+++ b/app/src/main/java/com/sandoval/thalesemployee/domain/base/BaseUseCase.kt
@@ -1,0 +1,26 @@
+package com.sandoval.thalesemployee.domain.base
+
+import com.sandoval.thalesemployee.data.network.Failure
+import com.sandoval.thalesemployee.data.utils.Either
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+
+abstract class BaseUseCase<in Params, out Type> where Type : Any {
+
+    abstract suspend fun run(params: Params): Flow<Either<Failure, Type>>
+
+    open operator fun invoke(
+        job: Job,
+        params: Params,
+        onResult: (Either<Failure, Type>) -> Unit = {}
+    ) {
+        val backgroundJob = CoroutineScope(job + Dispatchers.IO).async { run(params) }
+        CoroutineScope(job + Dispatchers.Main).launch {
+            val await = backgroundJob.await()
+            await.catch {
+                onResult(Either.Left(Failure.ServerError))
+            }.collect { d -> onResult(d) }
+        }
+    }
+}

--- a/app/src/main/java/com/sandoval/thalesemployee/domain/models/employee_list/DData.kt
+++ b/app/src/main/java/com/sandoval/thalesemployee/domain/models/employee_list/DData.kt
@@ -1,0 +1,9 @@
+package com.sandoval.thalesemployee.domain.models.employee_list
+
+data class DData(
+    val employeeAge: Int,
+    val employeeName: String,
+    val employeeSalary: Int,
+    val id: Int,
+    val profileImage: String
+)

--- a/app/src/main/java/com/sandoval/thalesemployee/domain/models/employee_list/DEmployeeListResponse.kt
+++ b/app/src/main/java/com/sandoval/thalesemployee/domain/models/employee_list/DEmployeeListResponse.kt
@@ -1,0 +1,7 @@
+package com.sandoval.thalesemployee.domain.models.employee_list
+
+data class DEmployeeListResponse(
+    val data: List<DData>,
+    val message: String,
+    val status: String
+)

--- a/app/src/main/java/com/sandoval/thalesemployee/domain/repository/IGetEmployeeListRepository.kt
+++ b/app/src/main/java/com/sandoval/thalesemployee/domain/repository/IGetEmployeeListRepository.kt
@@ -1,0 +1,13 @@
+package com.sandoval.thalesemployee.domain.repository
+
+import com.sandoval.thalesemployee.data.network.Failure
+import com.sandoval.thalesemployee.data.utils.Either
+import com.sandoval.thalesemployee.domain.models.employee_list.DData
+import kotlinx.coroutines.flow.Flow
+
+interface IGetEmployeeListRepository {
+
+    //Remote get employee list Service
+    suspend fun getEmployeeList(): Flow<Either<Failure, List<DData>>>
+
+}

--- a/app/src/main/java/com/sandoval/thalesemployee/domain/usecase/GetEmployeeListUseCase.kt
+++ b/app/src/main/java/com/sandoval/thalesemployee/domain/usecase/GetEmployeeListUseCase.kt
@@ -1,0 +1,17 @@
+package com.sandoval.thalesemployee.domain.usecase
+
+import com.sandoval.thalesemployee.data.network.Failure
+import com.sandoval.thalesemployee.data.utils.Either
+import com.sandoval.thalesemployee.domain.models.employee_list.DData
+import com.sandoval.thalesemployee.domain.repository.IGetEmployeeListRepository
+import com.sandoval.thalesemployee.domain.base.BaseUseCase
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetEmployeeListUseCase @Inject constructor(
+    private val iGetEmployeeListRepository: IGetEmployeeListRepository
+) : BaseUseCase<Unit, List<DData>>() {
+    override suspend fun run(params: Unit): Flow<Either<Failure, List<DData>>> {
+        return iGetEmployeeListRepository.getEmployeeList()
+    }
+}


### PR DESCRIPTION
- Add the domain layer to map all the data results and operations through the domain.
- Add domain models to be mapped by the data layer in the future
- Add the repository interface to the domain to be implemented in the data layer and to be injected in the UseCase
- Add the use case to get the employee list, to be injected through the viewmodel in the future
- Create 2 helper clases. Failure.kt to handle possible failure scenarios and Either.kt to be able to calculate the possible result of the operator when the usecase is consumed. Right (Success) Left (Error)