### PR TITLE
Add viewmodel for Employee list

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.application'
     id 'kotlin-android'
     id 'kotlin-kapt'
+    id 'kotlin-parcelize'
     id 'androidx.navigation.safeargs.kotlin'
     id 'dagger.hilt.android.plugin'
     id 'org.jetbrains.kotlin.android'

--- a/app/src/main/java/com/sandoval/thalesemployee/di/AppModule.kt
+++ b/app/src/main/java/com/sandoval/thalesemployee/di/AppModule.kt
@@ -4,6 +4,8 @@ import com.google.gson.GsonBuilder
 import com.sandoval.thalesemployee.BuildConfig
 import com.sandoval.thalesemployee.commons.BASE_URL
 import com.sandoval.thalesemployee.data.remote.api.ThalesEmployeeService
+import com.sandoval.thalesemployee.data.remote.repository.employee_list.RemoteDataGetEmployeeListRepository
+import com.sandoval.thalesemployee.domain.repository.employee_list.IGetEmployeeListRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -51,4 +53,10 @@ object AppModule {
     @Singleton
     fun provideApiService(retrofit: Retrofit): ThalesEmployeeService =
         retrofit.create(ThalesEmployeeService::class.java)
+
+    @Provides
+    @Singleton
+    fun providesGetEmployeeList(remoteDataGetEmployeeListRepository: RemoteDataGetEmployeeListRepository): IGetEmployeeListRepository =
+        remoteDataGetEmployeeListRepository
+
 }

--- a/app/src/main/java/com/sandoval/thalesemployee/ui/employee_list/models/DDataPresentation.kt
+++ b/app/src/main/java/com/sandoval/thalesemployee/ui/employee_list/models/DDataPresentation.kt
@@ -1,0 +1,13 @@
+package com.sandoval.thalesemployee.ui.employee_list.models
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class DDataPresentation(
+    val employeeAge: Int?,
+    val employeeName: String?,
+    val employeeSalary: Int?,
+    val id: Int?,
+    val profileImage: String?
+) : Parcelable

--- a/app/src/main/java/com/sandoval/thalesemployee/ui/employee_list/models/state/GetEmployeeListView.kt
+++ b/app/src/main/java/com/sandoval/thalesemployee/ui/employee_list/models/state/GetEmployeeListView.kt
@@ -1,0 +1,10 @@
+package com.sandoval.thalesemployee.ui.employee_list.models.state
+
+import com.sandoval.thalesemployee.ui.employee_list.models.DDataPresentation
+
+data class GetEmployeeListView(
+    val loading: Boolean = false,
+    val errorMessage: String? = null,
+    val isEmpty: Boolean = false,
+    val data: List<DDataPresentation>? = null
+)

--- a/app/src/main/java/com/sandoval/thalesemployee/ui/employee_list/viewmodel/GetEmployeeListViewModel.kt
+++ b/app/src/main/java/com/sandoval/thalesemployee/ui/employee_list/viewmodel/GetEmployeeListViewModel.kt
@@ -1,0 +1,61 @@
+package com.sandoval.thalesemployee.ui.employee_list.viewmodel
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.sandoval.thalesemployee.data.network.Failure
+import com.sandoval.thalesemployee.domain.models.employee_list.DData
+import com.sandoval.thalesemployee.domain.usecase.employee_list.GetEmployeeListUseCase
+import com.sandoval.thalesemployee.ui.employee_list.models.state.GetEmployeeListView
+import com.sandoval.thalesemployee.ui.mapper.toPresentation
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import javax.inject.Inject
+
+@HiltViewModel
+class GetEmployeeListViewModel @Inject constructor(
+    private val getEmployeeListUseCase: GetEmployeeListUseCase
+) : ViewModel() {
+
+    private val job = Job()
+
+    private val _employeeListModel = MutableLiveData<GetEmployeeListView>()
+    val employeeListModel: LiveData<GetEmployeeListView> get() = _employeeListModel
+
+    private val _errorMessage = MutableLiveData<String>()
+    val errorMessage: LiveData<String> get() = _errorMessage
+
+    init {
+        getData()
+    }
+
+    fun getData() {
+        _employeeListModel.value = GetEmployeeListView(loading = true)
+        getEmployeeListUseCase(job, Unit) {
+            it.fold(
+                ::handleFailure,
+                ::handleSuccess
+            )
+        }
+    }
+
+    private fun handleSuccess(data: List<DData>) {
+        if (data.isNotEmpty()) {
+            _employeeListModel.value =
+                GetEmployeeListView(data = data.map { it.toPresentation() })
+        } else {
+            _employeeListModel.value = GetEmployeeListView(isEmpty = true)
+        }
+    }
+
+    private fun handleFailure(failure: Failure) {
+        _employeeListModel.value = GetEmployeeListView(errorMessage = failure.toString())
+        _errorMessage.value = failure.toString()
+
+    }
+
+    override fun onCleared() {
+        job.cancel()
+        super.onCleared()
+    }
+}

--- a/app/src/main/java/com/sandoval/thalesemployee/ui/mapper/MapToPresentation.kt
+++ b/app/src/main/java/com/sandoval/thalesemployee/ui/mapper/MapToPresentation.kt
@@ -1,0 +1,12 @@
+package com.sandoval.thalesemployee.ui.mapper
+
+import com.sandoval.thalesemployee.domain.models.employee_list.DData
+import com.sandoval.thalesemployee.ui.employee_list.models.DDataPresentation
+
+fun DData.toPresentation() = DDataPresentation(
+    employeeAge = employeeAge ?: 0,
+    employeeName = employeeName ?: "",
+    employeeSalary = employeeSalary ?: 0,
+    id = id ?: 0,
+    profileImage = profileImage ?: ""
+)

--- a/app/src/test/java/com/sandoval/thalesemployee/utils/LiveDataUtilTest.kt
+++ b/app/src/test/java/com/sandoval/thalesemployee/utils/LiveDataUtilTest.kt
@@ -1,0 +1,47 @@
+package com.sandoval.thalesemployee.utils
+
+import androidx.annotation.VisibleForTesting
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+/**
+ * Gets the value of a [LiveData] or waits for it to have one, with a timeout.
+ *
+ * Use this extension from host-side (JVM) tests. It's recommended to use it alongside
+ * `InstantTaskExecutorRule` or a similar mechanism to execute tasks synchronously.
+ */
+
+@VisibleForTesting(otherwise = VisibleForTesting.NONE)
+fun <T> LiveData<T>.getOrAwaitValueTest(
+    time: Long = 2,
+    timeUnit: TimeUnit = TimeUnit.SECONDS,
+    afterObserve: () -> Unit = {}
+): T {
+    var data: T? = null
+    val latch = CountDownLatch(1)
+    val observer = object : Observer<T> {
+        override fun onChanged(o: T?) {
+            data = o
+            latch.countDown()
+            this@getOrAwaitValueTest.removeObserver(this)
+        }
+    }
+    this.observeForever(observer)
+
+    try {
+        afterObserve.invoke()
+
+        // Don't wait indefinitely if the LiveData is not set.
+        if (!latch.await(time, timeUnit)) {
+            throw TimeoutException("LiveData value was never set.")
+        }
+    } finally {
+        this.removeObserver(observer)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    return data as T
+}

--- a/app/src/test/java/com/sandoval/thalesemployee/viewmodel/employee_list/GetEmployeeListViewModelTest.kt
+++ b/app/src/test/java/com/sandoval/thalesemployee/viewmodel/employee_list/GetEmployeeListViewModelTest.kt
@@ -1,0 +1,53 @@
+package com.sandoval.thalesemployee.viewmodel.employee_list
+
+import com.google.common.truth.Truth
+import com.sandoval.thalesemployee.data.network.Failure
+import com.sandoval.thalesemployee.data.utils.Either
+import com.sandoval.thalesemployee.domain.models.employee_list.DData
+import com.sandoval.thalesemployee.domain.usecase.employee_list.GetEmployeeListUseCase
+import com.sandoval.thalesemployee.ui.employee_list.viewmodel.GetEmployeeListViewModel
+import com.sandoval.thalesemployee.ui.mapper.toPresentation
+import com.sandoval.thalesemployee.utils.UnitTest
+import com.sandoval.thalesemployee.utils.getOrAwaitValueTest
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import org.junit.Before
+import org.junit.Test
+
+class GetEmployeeListViewModelTest : UnitTest() {
+
+    @MockK
+    private lateinit var getEmployeeListUseCase: GetEmployeeListUseCase
+
+    private lateinit var getEmployeeListViewModel: GetEmployeeListViewModel
+
+    private lateinit var data: List<DData>
+
+    @Before
+    fun setUp() {
+        data = listOf(
+            DData(
+                employeeAge = 61,
+                employeeName = "Tiger Nixon",
+                employeeSalary = 320800,
+                id = 1,
+                profileImage = ""
+            )
+        )
+        getEmployeeListViewModel = GetEmployeeListViewModel(getEmployeeListUseCase)
+    }
+
+    @Test
+    fun `getData should return actual list`() {
+        every { getEmployeeListUseCase(any(), Unit, any()) }.answers {
+            lastArg<(Either<Failure, List<DData>>) -> Unit>()(Either.Right(data))
+        }
+        getEmployeeListViewModel.getData()
+        val res = getEmployeeListViewModel.employeeListModel.getOrAwaitValueTest()
+        Truth.assertThat(res.errorMessage).isNull()
+        Truth.assertThat(res.loading).isFalse()
+        Truth.assertThat(res.isEmpty).isFalse()
+        Truth.assertThat(res.data).isEqualTo(data.map { it.toPresentation() })
+    }
+
+}


### PR DESCRIPTION
 - Add the view-model layer for the feature employee list
- Add a custom state class to map the possible states of the employee list use-case in a view model: loading, empty, error or data (GetEmployeeListView)
- Add a custom mapper package in the UI to map the domain model to a UI model to be passed in the view-model, in this case for the employee list use-case
- Add a util class to be able to get the value of a LiveData, or waits for it to have one, with a timeout; to be used in the view-model unit-tests classes
- Add the view-model unit test for the employee list use-case